### PR TITLE
Fix invalid meta tag in blur tool

### DIFF
--- a/protardio-bg-tools/batch-blur.html
+++ b/protardio-bg-tools/batch-blur.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name viewport="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Background Blur Processor</title>
     <style>
         body {


### PR DESCRIPTION
## Summary
- fix the viewport meta tag in `protardio-bg-tools/batch-blur.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684114565194832b823e425b118575cf